### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
       dist: xenial
     - python: 3.6
     - python: 3.5
-    - python: 3.4
     - python: 2.7
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python-ci-static-analysis
 
 [![Build Status](https://travis-ci.org/hugovk/python-ci-static-analysis.svg?branch=master)](https://travis-ci.org/hugovk/python-ci-static-analysis)
-[![Python: 2.7, 3.4+](https://img.shields.io/badge/python-2.7,_3.4+-blue.svg)](https://www.python.org/downloads/)
+[![Python: 2.7, 3.5+](https://img.shields.io/badge/python-2.7,_3.5+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 Static analysis on Travis CI for Python projects


### PR DESCRIPTION
Version | Release date | Supported until
--- | ---------- | ----------
2.5 | 2006-09-19 | 2011-05-26
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

